### PR TITLE
Add Trustabl security scanning to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like how you're building a dynamic map of AI entrepreneurship challenges with tailored AI Coaches to guide founders. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [HIGH] CrewAI agent grants an unconstrained FileReadTool
   File: community_matchmaking_coach/src/ai_community_matchmaker/crew.py
   What it means: This agent wires FileReadTool with no file_path= pin, so the tool reads whatever path the model names at call time.

2. [HIGH] CrewAI agent grants an unconstrained FileReadTool
   File: community_matchmaking_coach/src/ai_community_matchmaker/crew.py
   What it means: This agent wires FileReadTool with no file_path= pin, so the tool reads whatever path the model names at call time.

3. [HIGH] CrewAI agent grants an unconstrained FileReadTool
   File: community_matchmaking_coach/src/ai_community_matchmaker/crew.py
   What it means: This agent wires FileReadTool with no file_path= pin, so the tool reads whatever path the model names at call time.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)